### PR TITLE
Implement early_cast option to support resharding on GPUs with less than 20gb vram

### DIFF
--- a/mesh_transformer/transformer_shard.py
+++ b/mesh_transformer/transformer_shard.py
@@ -171,7 +171,7 @@ class CausalTransformer:
             params = param_init_fn(key, x, x)
 
             return {
-                "params": to_f32(params),
+                "params": ("early_cast" in config and to_bf16 or to_f32)(params),
                 "step": np.array(0),
                 "opt_state": optimizer.init(params)
             }
@@ -232,11 +232,6 @@ class CausalTransformer:
                                                                  ["batch", ...]),
                                                         out_axes=["batch", ...],
                                                         axis_resources={'shard': 'mp', 'batch': 'dp'})
-
-        self.move_xmap = jax.experimental.maps.xmap(fun=lambda x, _: to_bf16(x),
-                                                    in_axes=(["shard", ...], ["batch", ...]),
-                                                    out_axes=["shard", ...],
-                                                    axis_resources={'shard': 'mp', 'batch': 'dp'})
 
         key = hk.PRNGSequence(42)
 

--- a/mesh_transformer/transformer_shard.py
+++ b/mesh_transformer/transformer_shard.py
@@ -171,7 +171,7 @@ class CausalTransformer:
             params = param_init_fn(key, x, x)
 
             return {
-                "params": ("early_cast" in config and to_bf16 or to_f32)(params),
+                "params": to_f32(params),
                 "step": np.array(0),
                 "opt_state": optimizer.init(params)
             }
@@ -232,6 +232,11 @@ class CausalTransformer:
                                                                  ["batch", ...]),
                                                         out_axes=["batch", ...],
                                                         axis_resources={'shard': 'mp', 'batch': 'dp'})
+
+        self.move_xmap = jax.experimental.maps.xmap(fun=lambda x, _: to_bf16(x),
+                                                    in_axes=(["shard", ...], ["batch", ...]),
+                                                    out_axes=["shard", ...],
+                                                    axis_resources={'shard': 'mp', 'batch': 'dp'})
 
         key = hk.PRNGSequence(42)
 

--- a/mesh_transformer/transformer_shard.py
+++ b/mesh_transformer/transformer_shard.py
@@ -171,7 +171,7 @@ class CausalTransformer:
             params = param_init_fn(key, x, x)
 
             return {
-                "params": to_f32(params),
+                "params": ("early_cast" in config and to_bf16 or to_f32)(params),
                 "step": np.array(0),
                 "opt_state": optimizer.init(params)
             }

--- a/resharding_example.py
+++ b/resharding_example.py
@@ -20,7 +20,7 @@ params = {
   "norm": "layernorm",
   "pe": "rotary",
   "pe_rotary_dims": 64,
-
+  "early_cast": True,
   "seq": 2048,
   "cores_per_replica": 1,  # only running on one GPU
   "per_replica_batch": 1,

--- a/resharding_example.py
+++ b/resharding_example.py
@@ -48,9 +48,6 @@ start = time.time()
 # here we load a checkpoint which was written with 8 shards into 1 shard
 network.state = read_ckpt(network.state, "step_383500/", 8, shards_out=cores_per_replica)
 
-network.state = network.move_xmap(network.state, np.zeros(cores_per_replica))
-
-
 def infer(context, top_p=0.9, temp=1.0, gen_len=512):
     tokens = tokenizer.encode(context)
 


### PR DESCRIPTION
It's likely this will work on a gpu with 16gb vram with a smaller "seq" size.

Without this change, the model immediately runs out of memory on "network = CausalTransformer(params)"