### PR TITLE
Significantly reduce vram usage when resharding on a single GPU.

### DIFF
--- a/mesh_transformer/transformer_shard.py
+++ b/mesh_transformer/transformer_shard.py
@@ -171,7 +171,7 @@ class CausalTransformer:
             params = param_init_fn(key, x, x)
 
             return {
-                "params": to_f32(params),
+                "params": ("early_cast" in config and to_bf16 or to_f32)(params),
                 "step": np.array(0),
                 "opt_state": optimizer.init(params)
             }
@@ -232,11 +232,6 @@ class CausalTransformer:
                                                                  ["batch", ...]),
                                                         out_axes=["batch", ...],
                                                         axis_resources={'shard': 'mp', 'batch': 'dp'})
-
-        self.move_xmap = jax.experimental.maps.xmap(fun=lambda x, _: to_bf16(x),
-                                                    in_axes=(["shard", ...], ["batch", ...]),
-                                                    out_axes=["shard", ...],
-                                                    axis_resources={'shard': 'mp', 'batch': 'dp'})
 
         key = hk.PRNGSequence(42)
 

--- a/mesh_transformer/transformer_shard.py
+++ b/mesh_transformer/transformer_shard.py
@@ -171,7 +171,7 @@ class CausalTransformer:
             params = param_init_fn(key, x, x)
 
             return {
-                "params": ("early_cast" in config and to_bf16 or to_f32)(params),
+                "params": to_f32(params),
                 "step": np.array(0),
                 "opt_state": optimizer.init(params)
             }
@@ -232,6 +232,11 @@ class CausalTransformer:
                                                                  ["batch", ...]),
                                                         out_axes=["batch", ...],
                                                         axis_resources={'shard': 'mp', 'batch': 'dp'})
+
+        self.move_xmap = jax.experimental.maps.xmap(fun=lambda x, _: to_bf16(x),
+                                                    in_axes=(["shard", ...], ["batch", ...]),
+                                                    out_axes=["shard", ...],
+                                                    axis_resources={'shard': 'mp', 'batch': 'dp'})
 
         key = hk.PRNGSequence(42)
 

--- a/mesh_transformer/transformer_shard.py
+++ b/mesh_transformer/transformer_shard.py
@@ -171,7 +171,7 @@ class CausalTransformer:
             params = param_init_fn(key, x, x)
 
             return {
-                "params": to_f32(params),
+                "params": ("early_cast" in config and to_bf16 or to_f32)(params),
                 "step": np.array(0),
                 "opt_state": optimizer.init(params)
             }

--- a/resharding_example.py
+++ b/resharding_example.py
@@ -48,6 +48,9 @@ start = time.time()
 # here we load a checkpoint which was written with 8 shards into 1 shard
 network.state = read_ckpt(network.state, "step_383500/", 8, shards_out=cores_per_replica)
 
+# move the state to CPU/system memory so it's not duplicated by xmap
+network.state = jax.device_put(network.state, jax.devices("cpu")[0])
+
 def infer(context, top_p=0.9, temp=1.0, gen_len=512):
     tokens = tokenizer.encode(context)
 

--- a/resharding_example.py
+++ b/resharding_example.py
@@ -20,7 +20,7 @@ params = {
   "norm": "layernorm",
   "pe": "rotary",
   "pe_rotary_dims": 64,
-
+  "early_cast": True,
   "seq": 2048,
   "cores_per_replica": 1,  # only running on one GPU
   "per_replica_batch": 1,

--- a/resharding_example.py
+++ b/resharding_example.py
@@ -1,4 +1,5 @@
-# This was tested with an A100, and peak memory usage is approximately 30GB when loading the model
+# This was tested with an RTX 3090, peak memory usage is approximately 22.4GB during inference, and 19GB when loading the model
+# The following environment variables were also used: XLA_PYTHON_CLIENT_PREALLOCATE=false XLA_PYTHON_CLIENT_ALLOCATOR=platform
 
 import time
 

--- a/resharding_example.py
+++ b/resharding_example.py
@@ -48,9 +48,6 @@ start = time.time()
 # here we load a checkpoint which was written with 8 shards into 1 shard
 network.state = read_ckpt(network.state, "step_383500/", 8, shards_out=cores_per_replica)
 
-network.state = network.move_xmap(network.state, np.zeros(cores_per_replica))
-
-
 def infer(context, top_p=0.9, temp=1.0, gen_len=512):
     tokens = tokenizer.encode(context)
 


### PR DESCRIPTION
Without this, the model is actually duplicated in memory due to xmap.

I am testing with a single RTX 3090 on Ubuntu 20.04.2 LTS.
jax versions:
```
jax==0.2.13
jaxlib==0.1.67+cuda111
```

I also run with the following environment variables, otherwise it OOMs during init regardless of this change:
```
XLA_PYTHON_CLIENT_PREALLOCATE=false
XLA_PYTHON_CLIENT_ALLOCATOR=platform
```

Some stats on running infer() with and without this change:

before:
```
seq     vram usage
512     21.1G
900     22.3G
```

after:
```
seq     vram usage
512     14.7G
900     15.3G
2048    22.4G
```

It still uses a bit more than that during initialization though.


