### PR TITLE
wget -c for continue download if file exists

### DIFF
--- a/colab_demo.ipynb
+++ b/colab_demo.ipynb
@@ -798,7 +798,7 @@
     "!apt install zstd\n",
     "\n",
     "# the \"slim\" version contain only bf16 weights and no optimizer parameters, which minimizes bandwidth and memory\n",
-    "!time wget https://the-eye.eu/public/AI/GPT-J-6B/step_383500_slim.tar.zstd\n",
+    "!time wget -c https://the-eye.eu/public/AI/GPT-J-6B/step_383500_slim.tar.zstd\n",
     "\n",
     "!time tar -I zstd -xf step_383500_slim.tar.zstd\n",
     "\n",


### PR DESCRIPTION
I've had to run the notebook twice every time it's from a fresh notebook. (Because it always requires me to kernel restart after the first wget/update/etc.) This results in double-downloading the .zstd file. (The new one becomes a .1 file.) The -c parameter should allow wget to skip the second download if the file already exists. (Or it will finish downloading if it's not completely downloaded.)