### PR TITLE
slim_model: options for float16, checkpoint selection

### DIFF
--- a/mesh_transformer/util.py
+++ b/mesh_transformer/util.py
@@ -81,6 +81,10 @@ def to_bf16(t):
     return jax.tree_map(lambda x: x.astype(jnp.bfloat16) if x.dtype == jnp.float32 else x, t)
 
 
+def to_f16(t):
+    return jax.tree_map(lambda x: x.astype(jnp.float16) if x.dtype == jnp.float32 else x, t)
+
+
 # identity in forward pass, psum in backward
 @jax.custom_vjp
 def f_psum(x):


### PR DESCRIPTION
Contains some additions I made to `slim_model.py` when I was using it with a finetuned model.

- `--f16`: converts to float16
  - Why: Since many people are doing inference with float16 weights, it seems better to just go directly to float16, without the bfloat16 step

- `--ckpt-step`: passing e.g. `--ckpt-step 401` will load from `step_401/` even if it's not the most recent checkpoint
  - Why: I wanted to convert the model with the lowest val loss, but usually there were 1 or more checkpoints after that step