### PR TITLE
Fix lr schedule in fine-tuning + add documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 A haiku library using the `xmap` operator in Jax for model parallelism of transformers.
 
 The parallelism scheme is similar to the [original Megatron-LM](https://arxiv.org/abs/1909.08053), which is efficient
-on TPUs due to the high speed 2d mesh network. 
+on TPUs due to the high speed 2d mesh network.
 
 This library is designed for scalability up to approximately 20B parameters on TPUv3s, beyond which different
-parallelism strategies should be used. See other implementations such as 
+parallelism strategies should be used. See other implementations such as
 [GPT-NeoX](https://github.com/EleutherAI/gpt-neox) or [DeepSpeed](https://github.com/microsoft/DeepSpeed) for that.
 
 One future direction for research is integrating this codebase with
@@ -50,7 +50,7 @@ The weights of GPT-J-6B are licensed under version 2.0 of the Apache License.
 
 ### Model Details
 
-| Hyperparameter    | Value  | 
+| Hyperparameter    | Value  |
 |-------------------|--------|
 | n_parameters      | 6,053,381,344 |
 | n_layers          | 28*    |
@@ -128,6 +128,12 @@ expect to be run directly on a TPUVM.
 Furthermore, there is an example (`resharding_example.py`) of how to convert the provided checkpoints (which have 8
 shards in the case of GPT-J-6B) down to a smaller number, such as for when running on GPU(s).
 
+### Fine-tuning
+
+To fine-tune the model, run `device_train.py` on a TPU VM.  If you use a TPU v8-3, you can fine-tune at a rate of ~5000 tokens/second, which should be sufficient for small-to-medium-size datasets.
+
+For usage information, run `python3 device_train.py --help`.
+
 # Citation
 
 To cite this repository:
@@ -152,7 +158,7 @@ To cite the weights of GPT-J-6B:
 }
 ```
 
-If you use this repository or any of the pretrained weights to do something cool, we would love to hear about it. 
+If you use this repository or any of the pretrained weights to do something cool, we would love to hear about it.
 Feel free to open a github issue or reach out over email (in profile).
 
 # TODO

--- a/device_train.py
+++ b/device_train.py
@@ -34,7 +34,8 @@ def parse_args():
     To prepare data in the expected data format:
         - use this notebook: https://github.com/EleutherAI/gpt-neo/blob/master/GPTNeo_example_notebook.ipynb
         - after creating .tfrecords files, save their paths to a index file under `data/`, see existing files for examples
-    """)
+    """,
+    formatter_class=argparse.RawTextHelpFormatter)
     parser.add_argument("--config", type=str, default=None, help="Config file location")
     parser.add_argument("--tune-model-path", type=str, default=None, help="Base model to finetune")
 

--- a/device_train.py
+++ b/device_train.py
@@ -25,8 +25,15 @@ def parse_args():
     # Parse command line arguments
     parser = argparse.ArgumentParser(description="""
     To use, download the full checkpoint archive, extract and upload to a GCS bucket, and set that as --tune-model-path
-    Modify the config file to point to where the checkpoints should be written during training, as well as the data
-    Check tfrecord_loader for the expected data format
+    Modify the config file:
+        - set `model_dir` to where the checkpoints should be written during training
+        - set `train_set`, `val_set` to index files for your data
+        - set `tpu_size` to 8 (if on a v3-8)
+        - set `warmup_steps`, `anneal_steps`, `lr`, `end_lr` to the lr schedule for your finetuning run
+        - the global step will reset to 0, keep that in mind when writing your lr schedule
+    To prepare data in the expected data format:
+        - use this notebook: https://github.com/EleutherAI/gpt-neo/blob/master/GPTNeo_example_notebook.ipynb
+        - after creating .tfrecords files, save their paths to a index file under `data/`, see existing files for examples
     """)
     parser.add_argument("--config", type=str, default=None, help="Config file location")
     parser.add_argument("--tune-model-path", type=str, default=None, help="Base model to finetune")
@@ -180,10 +187,12 @@ if __name__ == "__main__":
     train_loader = None
 
     if args.tune_model_path:
+        print('`--tune_model_path` passed: we are beginning a fine-tuning run')
+        fine_tuning = True
         initial_ckpt_state_path = args.tune_model_path
-        print('we are fine-tuning')
     else:
-        print('we are not fine-tuning')
+        print('`--tune_model_path` not passed: we are continuing a fine-tuning run from a checkpoint (or we are not fine-tuning)')
+        fine_tuning = False
         initial_ckpt_model_dir = model_dir
         initial_ckpt_path = f"gs://{bucket}/{initial_ckpt_model_dir}"
         meta_path = f"{initial_ckpt_path}/meta.json"
@@ -236,8 +245,19 @@ if __name__ == "__main__":
 
         if initial_ckpt_state_path:
             print("loading network")
+            if fine_tuning:
+                # get the scheduler step stored in the just-initialized optimizer
+                # should be zero
+                init_sched_state = network.state["opt_state"][-1]
+
             start = time.time()
             network.state = read_ckpt(network.state, initial_ckpt_state_path, devices.shape[1])
+
+            if fine_tuning:
+                # overwrite the loaded scheduler step with zeros
+                # this makes fine-tuning use the lr schedule in
+                network.state["opt_state"][-1] = init_sched_state
+
             print(f"network loaded in {time.time() - start:.06}s")
 
         print('compiling train fn')


### PR DESCRIPTION
Fixes an issue where `device_train.py` didn't use the lr schedule params in the config correctly.

There are several notions of global step in this repo:

1. numbers in checkpoint paths
2. step in `meta.json`
3. counts stored in optax transforms (one for each transform with step state)

**Currently:**

`device_train.py` resets 1 and 2 to zero, but kept the step values in 3.

The schedule continues from the loaded step, which generally means finetuning happens at `end_lr`.

**This PR:**

I reset the optax step value for the lr schedule to zero.  This will give the expected warmup/anneal behavior from the config.

There's also a global step in the `scale_by_adam` state, for bias correction.  I don't reset this, as we're loading the accumulators and they don't need bias correction

----
Also added/modified some documentation strings to address common questions from Discord.