### PR TITLE
Add Dockerization for GPT-J

### DIFF
--- a/docker/.env
+++ b/docker/.env
@@ -1,0 +1,8 @@
+DRYRUN=false
+DOMAIN=yourdomain.com
+SUBDOMAIN=gptj.api
+NGINX_PATH=./nginx_proxyvm.conf
+CERTS_PATH=/path/to/certs/
+DNS_KEYS=/path/to/keys/
+MODEL_DIR=/your/path/to/model/step_383500
+TPU_NAME=YOUR_TPU_NAME

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,18 @@
+# Have tested with a custom Ubuntu-1804 / Python 3.7 / Tensorflow 2.5.0 Base Image
+# Not tested with this image. 
+FROM tensorflow/tensorflow:latest
+
+WORKDIR /app/
+COPY . /app/
+RUN git clone https://github.com/kingoflolz/mesh-transformer-jax && \
+    pip install -r mesh-transformer-jax/requirements.txt && \
+    pip install mesh-transformer-jax/ jax==0.2.12 && \
+    pip install fastapi uvicorn requests aiofiles aiohttp && \
+    ln -s /app/start.sh /start.sh
+
+ENV PYTHONPATH /app:/app/mesh-transformer-jax:/usr/local/bin/python3
+ENV PATH $PYTHONPATH:$PATH
+ENV TOKENIZERS_PARALLELISM=true
+EXPOSE 80
+
+CMD ["/start.sh"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,69 @@
+# Deploying GPT-J (TPU VM) in a Docker Container
+
+This PR enables you to run GPT-J for Inference in a Docker Container, and has run stable over the past week. 
+
+The function currently requires 2 calls, the first is a POST call to /model/predict with the params
+
+```
+context: str
+temp: Optional[float] = 1.0
+top_p: Optional[float] = 0.9
+top_k: Optional[int] = 50
+length: Optional[int] = 256
+```
+
+This returns an ID (int) that is used to retrieve the prediction once the prediction is complete, rather than waiting until the prediction is done.
+
+The second function call is a POST call to /model/get_prediction with `qid=id` that was returned.
+
+## Getting Started
+
+You will need the following:
+1) TPU VM: A TPU (v2-8 works fine)
+2) Proxy VM: a second VM within the same zone. This VM will only serve to proxy all requests to the TPUVM, so it does not require a lot of resources.
+3) [Docker + Docker Compose](https://docs.docker.com/compose/install/) Installed on both VMs
+4) TPU VM and Proxy VM on the same GCP Network (default for most)
+5) Ports 80 and 443 exposed on the Proxy VM
+6) Your DNS records pointing to the External IP for Proxy VM.
+
+The GPTJ Checkpoint should be downloaded locally and the volume should be set as the variable MODEL_DIR in the .env file. This mounts the volume to the container, preventing multiple re-downloads.
+
+## Files to Modify
+
+`.env`
+
+```bash
+# Modify these values in .env
+DRYRUN=false # Set to True to prevent SSL Lets Encrypt Domain validation when testing
+DOMAIN=yourdomain.com # Set to your domain 
+SUBDOMAIN=gptj.api # Set to your subdomain. The endpoint will be gptj.api.yourdomain.com
+NGINX_PATH=./nginx_proxyvm.conf # Modify this conf file with the Internal IP of the TPU VM. This value will not change.
+CERTS_PATH=/path/to/certs/ # Set this to a path on the Proxy VM that be used to store SSL Certs. This path will automatically be created.
+DNS_KEYS=/path/to/keys/ # Set this to a path on the Proxy VM that be used to store DNS Keys. This path will automatically be created.
+MODEL_DIR=/your/path/to/model/step_383500 # Set this to the path on TPU VM that the model is stored in
+TPU_NAME=YOUR_TPU_NAME # Set this to your TPU Name as created
+```
+
+`nginx_proxyvm.conf`
+
+Modify the IP to your TPU VM's *Internal* IP Address
+
+
+## Running the Docker Container
+
+Assuming you are in this directory as the working directory.
+
+On TPU VM:
+
+`docker-compose up -d`
+
+On Proxy VM: 
+
+`docker-compose -f compose-proxy.yaml up`
+
+## Final Notes
+
+The reason you can't directly serve from the TPU VM is because there is no control over the TPU VM's port firewalls. I go into more details about [Dockerization within TPU VMs here](https://trisongz.medium.com/accessing-your-tpus-in-docker-containers-with-tpu-vm-e944f5909dd4). 
+
+The API is _very_ barebones and stripped down for simplicity. It's meant as a starting point and can be further extended for your needs.
+

--- a/docker/compose-proxy.yaml
+++ b/docker/compose-proxy.yaml
@@ -1,0 +1,29 @@
+version: "3.3"
+services:
+    gptjapi:
+        image: ghcr.io/linuxserver/swag
+        container_name: gptjapi
+        cap_add:
+            - NET_ADMIN
+        environment:
+            - PUID=1000
+            - PGID=1000
+            - TZ=America/Chicago
+            - URL=${DOMAIN}
+            - SUBDOMAINS=${SUBDOMAIN},
+            - VALIDATION=http
+            - STAGING=${DRYRUN}
+            - ONLY_SUBDOMAINS=true
+        volumes:
+            - ${NGINX_PATH}:/config/nginx/proxy-confs/app.subdomain.conf
+            - ${CERTS_PATH}:/config/etc/letsencrypt/
+            - ${DNS_KEYS}:/config/keys/
+        ports:
+            - 443:443
+            - 80:80
+        restart: unless-stopped
+        networks:
+            - production
+networks:
+    production:
+            

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,0 +1,31 @@
+version: "3.3"
+services:
+    gptjserver:
+        image: gptjserver
+        container_name: gptjserver
+        cap_add:
+            - ALL
+        environment:
+            - TPU_NAME=${TPU_NAME}
+            - TF_CPP_MIN_LOG_LEVEL=0
+            - XRT_TPU_CONFIG="localservice;0;localhost:51011"
+            - TF_XLA_FLAGS=--tf_xla_enable_xla_devices
+        build:
+            context: .
+            dockerfile: Dockerfile
+        ports:
+            - 8080:80
+        volumes:
+            - ${MODEL_DIR}:/app/model
+            - /var/run/docker.sock:/var/run/docker.sock
+            - /usr/share/tpu/:/usr/share/tpu/
+            - /lib/libtpu.so:/lib/libtpu.so
+        privileged: true
+        restart: unless-stopped
+        devices:
+            - "/dev:/dev"
+        networks:
+            - production
+networks:
+    production:
+            

--- a/docker/main.py
+++ b/docker/main.py
@@ -1,0 +1,53 @@
+
+
+import uvicorn
+import traceback
+import logging
+
+from fastapi import FastAPI
+from starlette.middleware.cors import CORSMiddleware
+from .payloads import CompletionPayload, CompletionResponse, QueueRequest, QueueResponse
+from .ops import get_gptj_model
+
+logger = logging.getLogger(__name__)
+
+app = FastAPI()
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+# globals
+MODEL_API = None
+
+
+@app.on_event("startup")
+async def startup_event():
+    global MODEL_API
+    try:
+        MODEL_API = get_gptj_model()
+        MODEL_API.load_model()
+        MODEL_API.start_background()
+    except Exception as e:
+        logger.debug(f"Model could not be loaded: {str(e)}")
+        traceback.print_exc()
+
+
+@app.post("/model/get_prediction")
+def get_prediction(payload: QueueRequest) -> CompletionResponse:
+    res = MODEL_API.wait_for_queue(payload.qid)
+    return CompletionResponse(**res)
+
+
+@app.post("/model/predict")
+def model_prediction(payload: CompletionPayload) -> QueueResponse:
+    res = MODEL_API.add_to_queue(payload)
+    return QueueResponse(qid=res['qid'])
+
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=8000, reload=True)

--- a/docker/nginx_proxyvm.conf
+++ b/docker/nginx_proxyvm.conf
@@ -1,0 +1,11 @@
+server {
+    listen 443;
+    server_name gptj.api.yourdomain.com;
+    include /config/nginx/ssl.conf;
+    client_max_body_size 0;
+    location / {
+        include /config/nginx/proxy.conf;
+        # The below IP should be your TPUVM Internal IP
+        proxy_pass http://10.000.0.1:8080;
+    }
+}

--- a/docker/ops.py
+++ b/docker/ops.py
@@ -1,0 +1,219 @@
+
+import os
+import time
+import jax
+import optax
+import threading
+import numpy as np
+import logging
+from queue import Queue, Empty
+from jax.experimental import maps
+from transformers import GPT2TokenizerFast
+
+from mesh_transformer.checkpoint import read_ckpt
+from mesh_transformer.sampling import nucleaus_sample
+from mesh_transformer.transformer_shard import CausalTransformer
+
+logger = logging.getLogger(__name__)
+
+# This prevents fastapi from creating multiple models in multi-worker mode
+# leading to OOM crashes
+gptj_model = None
+gptj_model_lock = threading.Lock()
+
+def compile_model():
+    global gptj_model
+    with gptj_model_lock:
+        if gptj_model:
+            return
+        gptj_model = GPTJ()
+
+def get_gptj_model():
+    compile_model()
+    return gptj_model
+
+def timer(start_time=None):
+    if not start_time:
+        return time.time()
+    return time.time() - start_time
+
+
+class GPTJ:
+    def __init__(self):
+        self.params = {
+            "layers": 28,
+            "d_model": 4096,
+            "n_heads": 16,
+            "n_vocab": 50400,
+            "norm": "layernorm",
+            "pe": "rotary",
+            "pe_rotary_dims": 64,
+            "seq": 2048,
+            "cores_per_replica": 8,
+            "per_replica_batch": 1,
+            "sampler": nucleaus_sample,
+            "optimizer": optax.scale(0)
+        }
+        self.tokenizer = GPT2TokenizerFast.from_pretrained('gpt2')
+        self.queue_ids = {}
+        self.qidx = 0
+        self.queue = Queue()
+        self.network = None
+        self.lock = threading.Lock()
+        self._alive_time = timer()
+    
+    def load_model(self):
+        if self.network:
+            logger.info('Attempting to reload model when model is loaded. Returning')
+            return
+        with self.lock:
+            logger.info('Loading Model')
+            start = timer()
+            logger.info(f"JAX Devices: {jax.device_count()}")
+            logger.info(f"JAX Runtime Initialized in {timer(start):.06} secs")
+            mesh_shape = (jax.device_count() // self.params['cores_per_replica'], self.params['cores_per_replica'])
+            self.devices = np.array(jax.devices()).reshape(mesh_shape)
+            self.total_batch = self.params['per_replica_batch'] * jax.device_count() // self.params['cores_per_replica'] * 8
+            maps.thread_resources.env = maps.ResourceEnv(maps.Mesh(self.devices, ('dp', 'mp')))
+            network = CausalTransformer(self.params)
+            logger.info(f'Loading Checkpoint')
+            network.state = read_ckpt(network.state, "/app/model/", self.devices.shape[1])
+            logger.info(f"GPTJ Network loaded in {timer(start):.06} secs. Total Batch Size: {self.total_batch}")
+            del network.state["opt_state"]
+            network.state = network.move_xmap(network.state, np.zeros(self.params['cores_per_replica']))
+            self.network = network
+
+    
+    def start_background(self):
+        with self.lock:
+            t = threading.Thread(target=self.background)
+            t.start()
+    
+    def prepare_item(self, context, length=256):
+        tokens = self.tokenizer.encode(context)
+        logger.info(tokens)
+        token_length = len(tokens)
+        pad_amount = self.params['seq'] - token_length
+        pad_amount = max(pad_amount, 0)
+        padded_tokens = np.pad(tokens, ((pad_amount, 0),)).astype(np.uint32)[-self.params['seq']:]
+        return {'tokens': padded_tokens, 'length': token_length}
+    
+    # Single Item - Not Tested
+    def infer(self, context, top_p=0.9, top_k=40, temp=1.0, length=256, **kwargs):
+        item = self.prepare_item(context, length)
+        batched_tokens = np.array([item['tokens']] * self.total_batch)
+        batched_lengths = np.array([item['length']] * self.total_batch)
+        start = timer()
+        output = self.network.generate(
+            batched_tokens, batched_lengths, length, 
+            {
+                "top_p": np.ones(self.total_batch) * top_p,
+                "top_k": np.ones(self.total_batch) * top_k,
+                "temp": np.ones(self.total_batch) * temp,
+            }
+        )
+        samples = []
+        decoded_tokens = output[1][0]
+        end_time = timer(start)
+        for o in decoded_tokens[:, :, 0]:
+            res = {
+                'context': context,
+                'completion': self.tokenizer.decode(o),
+                'time': end_time
+            }
+            samples.append(res)
+        logger.info(f"Completion done in {end_time:06} secs")
+        return samples
+    
+    def infer_batch(self, batch, **kwargs):
+        logger.info(f'Starting Inference on Batch')
+        batch_items = {'tokens': [], 'lengths': [], 'top_p': [], 'top_k': [], 'temp': []}
+        max_lengths, contexts = [], []
+        for req in batch:
+            req = self.to_data(req)
+            item = self.prepare_item(req['context'], req['length'])
+            batch_items['tokens'].append(item['tokens'])
+            batch_items['lengths'].append(item['length'])
+            batch_items['top_p'].append(req['top_p'])
+            batch_items['top_k'].append(req['top_k'])
+            batch_items['temp'].append(req['temp'])
+            max_lengths.append(req['length'])
+            contexts.append(req['context'])
+        
+        max_length = max(max_lengths)
+        for key, vals in batch_items.items():
+            batch_items[key] = np.array(vals)
+        start = timer()
+        logger.info(f'Completed Preparing Batch')
+        output = self.network.generate(
+            batch_items['tokens'], batch_items['lengths'], max_length, 
+            {
+                "top_p": batch_items['top_p'],
+                "top_k": batch_items['top_k'],
+                "temp": batch_items['temp'],
+            }
+        )
+        logger.info(f'Completed Generation')
+        samples = []
+        end_time = timer(start)
+        for pred, ctx in zip(output[1][0][:, :, 0], contexts):
+            res = {
+                'context': ctx,
+                'completion': self.tokenizer.decode(pred),
+                'time': end_time
+            }
+            samples.append(res)
+        logger.info(f"Completion done in {end_time:06} secs")
+        return samples
+
+    def add_to_queue(self, item):
+        self.qidx += 1
+        self.queue.put({'item': self.to_data(item), 'qidx': self.qidx})
+        self.queue_ids[self.qidx] = Queue()
+        return {'qid': self.qidx}
+
+    def wait_for_queue(self, qid):
+        if not self.queue_ids.get(qid):
+            return {'Error': 'QID not found'}
+        return self.queue_ids[qid].get()
+
+    def background(self):
+        logger.info(f'Init Background')
+        maps.thread_resources.env = maps.ResourceEnv(maps.Mesh(self.devices, ('dp', 'mp')))
+        while True:
+            batch, qids = [], []
+            while len(batch) <= self.total_batch:
+                try:
+                    req = self.queue.get(block=False)
+                    logger.info(f'Got Queue Item: {req}')
+                    batch.append(req['item'])
+                    qids.append(req['qidx'])
+                    
+                except Empty:
+                    if len(batch):
+                        break
+                    else:
+                        time.sleep(0.01)
+            batch_size = len(batch)
+            logger.info(f'Working on Batch: {batch_size} - {qids}')
+            while len(batch) < self.total_batch:
+                batch.append(self.placeholder_item)
+            start = timer()
+            results = self.infer_batch(batch)
+            for res, qid in zip(results, qids):
+                self.queue_ids[qid].put(res)
+            logger.info(f'Completed Current Batch of {batch_size} Items in {timer(start):.2f} secs')
+
+    @property
+    def placeholder_item(self):
+        return {'context': 'nada', 'top_p': 0.9, 'top_k': 40, 'temp': 1.0, 'length': 1}
+    
+    def to_data(self, item):
+        try:
+            return {'context': item.context, 'top_p': item.top_p, 'top_k': item.top_k, 'temp': item.temp, 'length': item.length}
+        except:
+            return {'context': item.get('context', ''), 'top_p': item.get('top_p', 0.9), 'top_k': item.get('top_k', 40), 'temp': item.get('temp', 1.0), 'length': item.get('length', 256)}
+
+    @property
+    def alive_time(self):
+        return timer(self._alive_time)

--- a/docker/payloads.py
+++ b/docker/payloads.py
@@ -1,0 +1,25 @@
+from pydantic import BaseModel
+from typing import Dict, Optional, Any, List
+
+
+class ModelPayload(BaseModel):
+    inputs: Optional[Any] = None
+    params: Optional[Dict]= {}
+
+class CompletionPayload(BaseModel):
+    context: str
+    temp: Optional[float] = 1.0
+    top_p: Optional[float] = 0.9
+    top_k: Optional[int] = 50
+    length: Optional[int] = 256
+
+class CompletionResponse(BaseModel):
+    context: str
+    completion: str
+    time: float
+
+class QueueResponse(BaseModel):
+    qid: int
+
+class QueueRequest(BaseModel):
+    qid: int

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -1,0 +1,29 @@
+#! /usr/bin/env sh
+set -e
+
+if [ -f /app/app/main.py ]; then
+    DEFAULT_MODULE_NAME=app.main
+elif [ -f /app/main.py ]; then
+    DEFAULT_MODULE_NAME=main
+fi
+
+MODULE_NAME=${MODULE_NAME:-$DEFAULT_MODULE_NAME}
+VARIABLE_NAME=${VARIABLE_NAME:-app}
+export APP_MODULE=${APP_MODULE:-"$MODULE_NAME:$VARIABLE_NAME"}
+
+HOST=${HOST:-0.0.0.0}
+PORT=${PORT:-80}
+LOG_LEVEL=${LOG_LEVEL:-info}
+
+# If there's a prestart.sh script in the /app directory or other path specified, run it before starting
+PRE_START_PATH=${PRE_START_PATH:-/app/prestart.sh}
+echo "Checking for script in $PRE_START_PATH"
+if [ -f $PRE_START_PATH ] ; then
+    echo "Running script $PRE_START_PATH"
+    . "$PRE_START_PATH"
+else 
+    echo "There is no script $PRE_START_PATH"
+fi
+
+# Start Uvicorn with live reload
+exec uvicorn --reload --reload-dir /app/mesh-transformer-jax --host $HOST --port $PORT --log-level $LOG_LEVEL "$APP_MODULE" --access-log


### PR DESCRIPTION
This PR adds Dockerization instructions and files to help deploy GPT-J as an API in TPU VM. 

Certain things have not been tested:
- The base Dockerfile image compatibility (there's no JAX docker image)
- Replication outside of our own GCP account
- SSL Issuance with a DNS that is not CloudFlare