### PR TITLE
Return probabilities from CausalTransformer.generate()

### DIFF
--- a/mesh_transformer/transformer_shard.py
+++ b/mesh_transformer/transformer_shard.py
@@ -190,8 +190,9 @@ class CausalTransformer:
 
                     output, new_state = transformer.generate_once(next_token, decode_state)
                     next_token, sample_info = sampler(sample_key, output, sampler_input, **sampler_options)
+                    probabilities = jax.nn.softmax(output)
 
-                    output = (next_token, sample_info)
+                    output = (next_token, sample_info, probabilities)
                     new_carry = (next_token, new_state, new_key)
                     return new_carry, output
 

--- a/mesh_transformer/transformer_shard.py
+++ b/mesh_transformer/transformer_shard.py
@@ -176,7 +176,7 @@ class CausalTransformer:
                 "opt_state": optimizer.init(params)
             }
 
-        def generate(state, key, ctx, ctx_length, aux, sampler_options, return_logits=False):
+        def generate(state, key, ctx, ctx_length, aux, sampler_options):
             sampler = config["sampler"]
             gen_length = self.gen_length
 
@@ -191,7 +191,7 @@ class CausalTransformer:
                     logits, new_state = transformer.generate_once(next_token, decode_state)
                     next_token, sample_info = sampler(sample_key, logits, sampler_input, **sampler_options)
 
-                    if return_logits:
+                    if self.return_logits:
                         output = (next_token, sample_info, logits)
                     else:
                         output = (next_token, sample_info)
@@ -308,6 +308,7 @@ class CausalTransformer:
         batch_size = ctx.shape[0]
         aux = jnp.zeros((batch_size, gen_length), dtype=jnp.uint32)
         self.gen_length = gen_length
+        self.return_logits = return_logits
 
         return self.generate_xmap(self.state,
                                   jnp.array(key.take(batch_size)),


### PR DESCRIPTION
Convert logits to probabilities for all classes at every generation step and return them as single tensor with shape (1, gen_length, 1, vocab) in the output of CausalTransformer.generate()

resolves #41 