### PR TITLE
Fixes for the create_finetune_tfrecords script

### DIFF
--- a/create_finetune_tfrecords.py
+++ b/create_finetune_tfrecords.py
@@ -255,6 +255,9 @@ def create_tfrecords(files, args):
         if ep_ix == 0:
             ep_len = len(sequences_for_this_epoch)
 
+
+    all_sequences_across_epochs = list(sequence_chunking_generator(all_sequences_across_epochs))
+
     final_seq_len = len(all_sequences_across_epochs[-1])
     if final_seq_len < 2049:
         print(f"dropped {final_seq_len} tokens of trailing data")

--- a/create_finetune_tfrecords.py
+++ b/create_finetune_tfrecords.py
@@ -128,13 +128,9 @@ def write_to_file(writer, data):
     writer.write(tf_example.SerializeToString())
 
 
-def write_tfrecord(files, fp):
-    chunks = files
-    files_per = len(files)
-
+def write_tfrecord(sequences, fp):
     with tf.io.TFRecordWriter(fp) as writer:
-        for f in files:
-            write_to_file(writer, f)
+        write_to_file(writer, sequences)
 
 
 def split_list(l, n):

--- a/create_finetune_tfrecords.py
+++ b/create_finetune_tfrecords.py
@@ -254,7 +254,6 @@ def create_tfrecords(files, args):
 
     print(type(all_sequences_across_epochs))
     print(type(all_sequences_across_epochs[0]))
-    print(type(all_sequences_across_epochs[0][0]))
 
     fp = os.path.join(args.output_dir, f"{args.name}_{total_sequence_len}.tfrecords")
     write_tfrecord(all_sequences_across_epochs, fp)

--- a/create_finetune_tfrecords.py
+++ b/create_finetune_tfrecords.py
@@ -252,16 +252,6 @@ def create_tfrecords(files, args):
 
     full_seqs, trailing_data = postprocess_sequences(sequences_first_epoch, args, encoder)
 
-    # sequences_first_epoch = list(sequence_chunking_generator(sequences_first_epoch))
-    #
-    # full_seqs_first_epoch, trailing_data_first_epoch = sequences_first_epoch[:-1], sequences_first_epoch[-1]
-    #
-    # if args.min_unique_tokens > 0:
-    #     full_seqs_first_epoch = list(enforce_min_unique(full_seqs_first_epoch, args.min_unique_tokens, enc, args.verbose))
-    #
-    # if not args.preserve_data_order:
-    #     random.shuffle(full_seqs_first_epoch)
-
     all_sequences_across_epochs.extend(full_seqs)
 
     # ep 2+
@@ -275,8 +265,6 @@ def create_tfrecords(files, args):
         all_sequences_across_epochs.extend(full_seqs)
 
     # final
-    all_sequences_across_epochs = list(sequence_chunking_generator(all_sequences_across_epochs))
-
     print(f"dropped {len(trailing_data)} tokens of trailing data")
 
     total_sequence_len = len(all_sequences_across_epochs)

--- a/create_finetune_tfrecords.py
+++ b/create_finetune_tfrecords.py
@@ -123,7 +123,6 @@ def write_to_file(writer, data):
     """
     writes data to tfrecord file
     """
-    print(("data", len(data)))
     feature = {
         "text": _int64_feature(data)
     }

--- a/create_finetune_tfrecords.py
+++ b/create_finetune_tfrecords.py
@@ -259,6 +259,10 @@ def create_tfrecords(files, args):
 
     total_sequence_len = len(all_sequences_across_epochs)
 
+    print(type(all_sequences_across_epochs))
+    print(type(all_sequences_across_epochs[0]))
+    print(type(all_sequences_across_epochs[0][0]))
+
     fp = os.path.join(args.output_dir, f"{args.name}_{total_sequence_len}.tfrecords")
     write_tfrecord(all_sequences_across_epochs, fp)
 

--- a/create_finetune_tfrecords.py
+++ b/create_finetune_tfrecords.py
@@ -121,6 +121,7 @@ def write_to_file(writer, data):
     """
     writes data to tfrecord file
     """
+    print(("data", data))
     feature = {
         "text": _int64_feature(data)
     }
@@ -130,7 +131,8 @@ def write_to_file(writer, data):
 
 def write_tfrecord(sequences, fp):
     with tf.io.TFRecordWriter(fp) as writer:
-        write_to_file(writer, sequences)
+        for seq in sequences:
+            write_to_file(writer, seq)
 
 
 def split_list(l, n):

--- a/create_finetune_tfrecords.py
+++ b/create_finetune_tfrecords.py
@@ -121,7 +121,7 @@ def write_to_file(writer, data):
     """
     writes data to tfrecord file
     """
-    print(("data", data))
+    print(("data", len(data)))
     feature = {
         "text": _int64_feature(data)
     }
@@ -235,6 +235,8 @@ def create_tfrecords(files, args):
 
         for f in tqdm(files, mininterval=10, smoothing=0):
             sequences_for_this_epoch.extend(archive_to_tokens(f, enc, args))
+
+        sequences_for_this_epoch = list(sequence_generator(sequences_for_this_epoch))
 
         if not args.preserve_data_order:
             random.shuffle(sequences_for_this_epoch)

--- a/create_finetune_tfrecords.py
+++ b/create_finetune_tfrecords.py
@@ -237,13 +237,6 @@ def create_tfrecords(files, args):
 
         for f in tqdm(files, mininterval=10, smoothing=0):
             for tokenized_files in archive_to_tokens(f, enc, args):
-                # if the last chunk < chunk size, take it and append it to the beginning of the next file
-                data_to_prepend = []
-                n_tokens = len(tokenized_files[-1])
-                if n_tokens < 2049:
-                    data = tokenized_files.pop(-1)
-                    data_to_prepend = data
-
                 sequences_for_this_epoch.extend(tokenized_files)
 
         if not args.preserve_data_order:

--- a/create_finetune_tfrecords.py
+++ b/create_finetune_tfrecords.py
@@ -242,7 +242,9 @@ def create_tfrecords(files, args):
             random.shuffle(sequences_for_this_epoch)
 
         if args.min_unique_tokens > 0:
-            sequences_for_this_epoch = list(enforce_min_unique(sequences_for_this_epoch, args.min_unique_tokens, enc, args.verbose))
+            full_seqs, trailing_data = sequences_for_this_epoch[:-1], sequences_for_this_epoch[-1]
+            sequences_for_this_epoch = list(enforce_min_unique(full_seqs, args.min_unique_tokens, enc, args.verbose))
+            sequences_for_this_epoch.append(trailing_data)
 
         all_sequences_across_epochs.extend(sequences_for_this_epoch)
 

--- a/create_finetune_tfrecords.py
+++ b/create_finetune_tfrecords.py
@@ -277,10 +277,7 @@ def create_tfrecords(files, args):
     # final
     all_sequences_across_epochs = list(sequence_chunking_generator(all_sequences_across_epochs))
 
-    final_seq_len = len(all_sequences_across_epochs[-1])
-    if final_seq_len < 2049:
-        print(f"dropped {final_seq_len} tokens of trailing data")
-        all_sequences_across_epochs = all_sequences_across_epochs[:-1]
+    print(f"dropped {len(trailing_data)} tokens of trailing data")
 
     total_sequence_len = len(all_sequences_across_epochs)
 

--- a/create_finetune_tfrecords.py
+++ b/create_finetune_tfrecords.py
@@ -232,8 +232,7 @@ def create_tfrecords(files, args):
         print(f'starting epoch {ep_ix}\n\t{len(all_sequences_across_epochs)} sequences so far\n\t{len(data_to_prepend)} tokens rolled over from last epoch\n\tfirst file this ep is {files[0]}')
 
         for f in tqdm(files, mininterval=10, smoothing=0):
-            for tokenized_files in archive_to_tokens(f, enc, args):
-                sequences_for_this_epoch.extend(tokenized_files)
+            sequences_for_this_epoch.extend(archive_to_tokens(f, enc, args))
 
         if not args.preserve_data_order:
             random.shuffle(sequences_for_this_epoch)

--- a/create_finetune_tfrecords.py
+++ b/create_finetune_tfrecords.py
@@ -236,7 +236,7 @@ def create_tfrecords(files, args):
         print(f'starting epoch {ep_ix}\n\t{len(all_sequences_across_epochs)} sequences so far\n\t{len(data_to_prepend)} tokens rolled over from last epoch\n\tfirst file this ep is {files[0]}')
 
         for f in tqdm(files, mininterval=10, smoothing=0):
-            for tokenized_files in archive_to_tokens(f, enc, args, prefix=data_to_prepend):
+            for tokenized_files in archive_to_tokens(f, enc, args):
                 # if the last chunk < chunk size, take it and append it to the beginning of the next file
                 data_to_prepend = []
                 n_tokens = len(tokenized_files[-1])

--- a/create_finetune_tfrecords.py
+++ b/create_finetune_tfrecords.py
@@ -231,7 +231,7 @@ def create_tfrecords(files, args):
         else:
             random.shuffle(files)
 
-        print(f'starting epoch {ep_ix}\n\t{len(all_sequences_across_epochs)} sequences so far\n\t{len(data_to_prepend)} tokens rolled over from last epoch\n\tfirst file this ep is {files[0]}')
+        print(f'starting epoch {ep_ix}\n\t{len(all_sequences_across_epochs)} sequences so far\n\tfirst file this ep is {files[0]}')
 
         for f in tqdm(files, mininterval=10, smoothing=0):
             sequences_for_this_epoch.extend(file_to_chunks_generator(f, enc, args))

--- a/create_finetune_tfrecords.py
+++ b/create_finetune_tfrecords.py
@@ -255,7 +255,6 @@ def create_tfrecords(files, args):
     docs = read_files_to_tokenized_docs(files, args, encoder)
 
     full_seqs, trailing_data = chunk_and_finalize(docs, args, encoder)
-    print(f"dropped {len(trailing_data)} tokens of trailing data")
 
     all_sequences_across_epochs.extend(full_seqs)
 
@@ -274,6 +273,7 @@ def create_tfrecords(files, args):
         all_sequences_across_epochs.extend(full_seqs)
 
     # final
+    print(f"dropped {len(trailing_data)} tokens of trailing data")
 
     total_sequence_len = len(all_sequences_across_epochs)
 

--- a/create_finetune_tfrecords.py
+++ b/create_finetune_tfrecords.py
@@ -45,11 +45,6 @@ def parse_args():
     minu_help += " Set <= 0 to disable. If enabled, 200 is a good default value. (Default: 0)"
     cleaning_args.add_argument("--min-unique-tokens", type=int, default=0,
                                help=minu_help)
-    eot_text_help = "Treats the string '<|endoftext|>' inside files as text rather than a document separator."
-    eot_text_help += " Not appropriate if your dataset is already concatenate on '<|endoftext|>'."
-    cleaning_args.add_argument("--treat-eot-as-text",
-                               default=False, action="store_true",
-                               help=eot_text_help)
 
     shuffle_pack_args = parser.add_argument_group('data shuffling/packing arguments')
     repack_ep_help = "Repeat the data N_REPACK_EPOCHS times, shuffled differently in each repetition. Recommended for multi-epoch training (set this to your intended number of epochs)."
@@ -207,8 +202,7 @@ def file_to_chunks_generator(file_path, encoder, args):
     """
     reader = Reader(file_path)
     string_iterable = reader.stream_data(threaded=False)
-    if not args.treat_eot_as_text:
-        string_iterable = eot_splitting_generator(string_iterable, encoder)
+    string_iterable = eot_splitting_generator(string_iterable, encoder)
 
     token_list_gen = prep_and_tokenize_generator(string_iterable,
                                                  encoder,
@@ -254,7 +248,6 @@ def create_tfrecords(files, args):
 
         if ep_ix == 0:
             ep_len = len(sequences_for_this_epoch)
-
 
     all_sequences_across_epochs = list(sequence_chunking_generator(all_sequences_across_epochs))
 

--- a/create_finetune_tfrecords.py
+++ b/create_finetune_tfrecords.py
@@ -160,9 +160,10 @@ def eot_splitting_generator(string_iterable, encoder):
     """
     Given strings, splits them internally on <|endoftext|> and yields (generally more) strings
     """
-    for d in doc.split(encoder.eos_token):
-        if len(d) > 0:
-            yield d
+    for doc in string_iterable:
+        for d in doc.split(encoder.eos_token):
+            if len(d) > 0:
+                yield d
 
 
 def prep_and_tokenize_generator(string_iterable, encoder, normalize_with_ftfy, normalize_with_wikitext_detokenize):


### PR DESCRIPTION
I noticed a problem with the `create_finetune_tfrecords` script I added recently.  It didn't work in the intended way when given long text files already "packed" with <|endoftext|>.

The problem was very hard to fix in the existing implementation (lightly adapted from create_tfrecords.py), because different levels of processing (archive, file, document, token sequence) were not cleanly separated in the code.

I refactored the code to separate these levels more clearly:

- `prep_and_tokenize_generator`:  iterable of strings --> iterable of tokenized documents
- `file_to_tokenized_docs_generator`: one file --> iterable of tokenized documents
- `arrays_to_sequences`: iterable of tokenized documents --> list of equal-length token arrays

I've tested this with a short test dataset in various settings:

- a single packed file vs. one file per document
- single or multiple "repack epochs"
- shuffling or not shuffling
- with / without the minimum unique token option

and did manual review + an automated test to check there were no unexpectedly truncated sequences in the output file.

Also did manual + automated test on the full val set for a real problem.

The diff is pretty unreadable, so just reading the new version is recommended