### PR TITLE
Measure grad norm and noise scale in finetuning + fix grad clip in V1 CausalTransformer

### DIFF
--- a/device_train.py
+++ b/device_train.py
@@ -276,11 +276,6 @@ if __name__ == "__main__":
         loss, last_loss, grad_norm, grad_norm_micro = train_step(
             network, train_dataset.get_samples()
         )
-        print(("loss", loss))
-        print(("last_loss", last_loss))
-        print(("grad_norm", grad_norm))
-        print(("grad_norm / gradient_accumulation_steps", grad_norm / gradient_accumulation_steps))
-        print(("grad_norm_micro", grad_norm_micro))
         step += 1
         print(f"Train fn compiled in {time.time() - start:.06}s")
 

--- a/device_train.py
+++ b/device_train.py
@@ -276,6 +276,11 @@ if __name__ == "__main__":
         loss, last_loss, grad_norm, grad_norm_micro = train_step(
             network, train_dataset.get_samples()
         )
+        print(("loss", loss))
+        print(("last_loss", last_loss))
+        print(("grad_norm", grad_norm))
+        print(("grad_norm / gradient_accumulation_steps", grad_norm / gradient_accumulation_steps))
+        print(("grad_norm_micro", grad_norm_micro))
         step += 1
         print(f"Train fn compiled in {time.time() - start:.06}s")
 

--- a/device_train.py
+++ b/device_train.py
@@ -341,7 +341,7 @@ if __name__ == "__main__":
 
             # compute G_noise and S_noise
             # from "An Empirical Model of Large-Batch Training" Appendix A.1
-            # here, B_large = gradient_accumulation_steps, and B_small = 1 for convenience
+            # here, B_big = gradient_accumulation_steps, and B_small = 1 for convenience
             gbsmall = grad_norm_micro ** 2
             gbbig = grad_norm ** 2
             G_noise = (gradient_accumulation_steps * gbbig - gbsmall) / (

--- a/device_train.py
+++ b/device_train.py
@@ -341,6 +341,7 @@ if __name__ == "__main__":
 
             # compute G_noise and S_noise
             # from "An Empirical Model of Large-Batch Training" Appendix A.1
+            # here, B_large = gradient_accumulation_steps, and B_small = 1 for convenience
             gbsmall = grad_norm_micro ** 2
             gbbig = grad_norm ** 2
             G_noise = (gradient_accumulation_steps * gbbig - gbsmall) / (

--- a/device_train.py
+++ b/device_train.py
@@ -109,9 +109,14 @@ def train_step(network, data):
         "target": data[:, :, 1:],
     }
 
-    loss, last_loss = network.train(inputs)
+    loss, last_loss, grad_norm, grad_norm_micro = network.train(inputs)
 
-    return np.array(loss).mean(), np.array(last_loss).mean()
+    return (
+        np.array(loss).mean(),
+        np.array(last_loss).mean(),
+        np.array(grad_norm).mean(),
+        np.array(grad_norm_micro).mean(),
+    )
 
 
 def eval_step(network, data):
@@ -160,6 +165,9 @@ if __name__ == "__main__":
     lr = params["lr"]
     end_lr = params["end_lr"]
     weight_decay = params["weight_decay"]
+
+    # alpha parameter for the exponential moving averages used to compute B_simple
+    noise_scale_alpha = params.get("noise_scale_alpha", 0.01)
 
     opt = optax.chain(
         optax.scale(1 / gradient_accumulation_steps),
@@ -232,14 +240,14 @@ if __name__ == "__main__":
 
     val_sets = {}
 
-    for k, v in params['val_set'].items():
-        val_sets[k] = TFRecordNewInputs(f"data/{v}",
-                                        batch_size=(global_val_batch,),
-                                        sample_size=seq)
+    for k, v in params["val_set"].items():
+        val_sets[k] = TFRecordNewInputs(
+            f"data/{v}", batch_size=(global_val_batch,), sample_size=seq
+        )
 
     # tok/sec metrics
-    windows_per_step = gradient_accumulation_steps * (per_replica_batch * tpu_size // cores_per_replica)
-    tokens_per_step = params['seq'] * windows_per_step
+    sequences_per_step = gradient_accumulation_steps * (per_replica_batch * tpu_size // cores_per_replica)
+    tokens_per_step = params['seq'] * sequences_per_step
 
     # load + run
     with jax.experimental.maps.mesh(devices, ('dp', 'mp')):
@@ -265,7 +273,9 @@ if __name__ == "__main__":
 
         print('compiling train fn')
         start = time.time()
-        train_step(network, train_dataset.get_samples())
+        loss, last_loss, grad_norm, grad_norm_micro = train_step(
+            network, train_dataset.get_samples()
+        )
         step += 1
         print(f"Train fn compiled in {time.time() - start:.06}s")
 
@@ -277,6 +287,9 @@ if __name__ == "__main__":
         print(f"Eval fn compiled in {time.time() - start:.06}s")
 
         wandb.init(project='mesh-transformer-jax', name=params["name"], config=params)
+
+        G_noise_avg = None
+        S_noise_avg = None
 
         while True:
             if (step % ckpt_every == 1) or step == total_steps:
@@ -306,10 +319,75 @@ if __name__ == "__main__":
                 exit()
 
             start = time.time()
-            loss, last_loss = train_step(network, train_dataset.get_samples())
+            loss, last_loss, grad_norm, grad_norm_micro = train_step(
+                network, train_dataset.get_samples()
+            )
             step += 1
 
             steps_per_sec = 1 / (time.time() - start)
             tokens_per_sec = tokens_per_step * steps_per_sec
 
-            wandb.log({'train/loss': loss, 'train/last_loss': last_loss, 'train/steps_per_sec': steps_per_sec, 'train/tokens_per_sec': tokens_per_sec}, step)
+            sequences_processed = sequences_per_step * step
+            tokens_processed = tokens_per_step * step
+
+            ### compute summary stats about the gradient
+
+            # converts from grads-summed-over-microbatch (what `CasualTransformer.train` computes)
+            # to grads-averaged-over-microbatch (what we want)
+            #
+            # (when taking gradient steps, the same conversion happens inside the optimizer
+            #  via optax.scale(1 / gradient_accumulation_steps))
+            grad_norm = grad_norm / gradient_accumulation_steps
+
+            # compute G_noise and S_noise
+            # from "An Empirical Model of Large-Batch Training" Appendix A.1
+            gbsmall = grad_norm_micro ** 2
+            gbbig = grad_norm ** 2
+            G_noise = (gradient_accumulation_steps * gbbig - gbsmall) / (
+                gradient_accumulation_steps - 1
+            )
+            S_noise = (gbsmall - gbbig) / (1 - 1 / gradient_accumulation_steps)
+
+            noise_scale_stats = {
+                "noise/G_noise": G_noise,
+                "noise/S_noise": S_noise,
+            }
+
+            # heuristic to avoid reporting G_noise in very early training when gradients are large
+            # (these take a long time to wash out of the moving average that defines B_simple)
+            use_step_in_noise_avgs = gbbig < 2
+
+            if use_step_in_noise_avgs:
+                # compute moving averages of G_noise and S_noise, for B_simple
+                if G_noise_avg is None:
+                    G_noise_avg = G_noise
+                else:
+                    G_noise_avg = (1 - noise_scale_alpha) * G_noise_avg + noise_scale_alpha * G_noise
+
+                if S_noise_avg is None:
+                    S_noise_avg = S_noise
+                else:
+                    S_noise_avg = (1 - noise_scale_alpha) * S_noise_avg + noise_scale_alpha * S_noise
+
+                B_simple = S_noise_avg / G_noise_avg
+
+                noise_scale_stats.update(
+                    {
+                        "noise/G_noise_avg": G_noise_avg,
+                        "noise/S_noise_avg": S_noise_avg,
+                        "noise/B_simple": B_simple,
+                    }
+                )
+
+            wandb_stats = {
+                "train/loss": loss,
+                "train/last_loss": last_loss,
+                "train/steps_per_sec": steps_per_sec,
+                "train/tokens_per_sec": tokens_per_sec,
+                "train/grad_norm": grad_norm,
+                "sequences_processed": sequences_processed,
+                "tokens_processed": tokens_processed,
+            }
+            wandb_stats.update(noise_scale_stats)
+
+            wandb.log(wandb_stats, step)

--- a/mesh_transformer/build_model.py
+++ b/mesh_transformer/build_model.py
@@ -39,7 +39,7 @@ def build_model(params, tpu_name, region, preemptible, version=1):
 
     opt = optax.chain(
         optax.scale(1 / gradient_accumulation_steps),
-        clip_by_global_norm(1),
+        clip_by_global_norm(1, use_psum=(version == 1)),
         optax.scale_by_adam(),
         additive_weight_decay(weight_decay),
         optax.scale(-1),

--- a/mesh_transformer/util.py
+++ b/mesh_transformer/util.py
@@ -26,7 +26,7 @@ def gpt3_schedule(warmup_steps,
     return sch
 
 
-def global_norm(updates):
+def global_norm(updates, use_psum=True):
     pre_sqrt = sum([jnp.sum(jnp.square(x)) for x in jax.tree_leaves(updates)])
     pre_sqrt = jax.lax.psum(pre_sqrt, "shard")
     return jnp.sqrt(pre_sqrt)
@@ -36,7 +36,7 @@ class ClipByGlobalNormState(OptState):
     """The `clip_by_global_norm` transformation is stateless."""
 
 
-def clip_by_global_norm(max_norm) -> GradientTransformation:
+def clip_by_global_norm(max_norm, use_psum=True) -> GradientTransformation:
     """Clip updates using their global norm.
 
     References:
@@ -54,7 +54,7 @@ def clip_by_global_norm(max_norm) -> GradientTransformation:
 
     def update_fn(updates, state, params=None):
         del params
-        g_norm = global_norm(updates)
+        g_norm = global_norm(updates, use_psum=use_psum)
         trigger = g_norm < max_norm
         updates = jax.tree_map(
             lambda t: jnp.where(trigger, t, (t / g_norm) * max_norm), updates)

--- a/mesh_transformer/util.py
+++ b/mesh_transformer/util.py
@@ -28,7 +28,8 @@ def gpt3_schedule(warmup_steps,
 
 def global_norm(updates, use_psum=True):
     pre_sqrt = sum([jnp.sum(jnp.square(x)) for x in jax.tree_leaves(updates)])
-    pre_sqrt = jax.lax.psum(pre_sqrt, "shard")
+    if use_psum:
+        pre_sqrt = jax.lax.psum(pre_sqrt, "shard")
     return jnp.sqrt(pre_sqrt)
 
 

--- a/mesh_transformer/util.py
+++ b/mesh_transformer/util.py
@@ -28,9 +28,7 @@ def gpt3_schedule(warmup_steps,
 
 def global_norm(updates):
     pre_sqrt = sum([jnp.sum(jnp.square(x)) for x in jax.tree_leaves(updates)])
-    print(f"global_norm: before psum: {pre_sqrt}")
     pre_sqrt = jax.lax.psum(pre_sqrt, "shard")
-    print(f"global_norm: after psum: {pre_sqrt}")
     return jnp.sqrt(pre_sqrt)
 
 

--- a/mesh_transformer/util.py
+++ b/mesh_transformer/util.py
@@ -28,7 +28,9 @@ def gpt3_schedule(warmup_steps,
 
 def global_norm(updates):
     pre_sqrt = sum([jnp.sum(jnp.square(x)) for x in jax.tree_leaves(updates)])
+    print(f"global_norm: before psum: {pre_sqrt}")
     pre_sqrt = jax.lax.psum(pre_sqrt, "shard")
+    print(f"global_norm: after psum: {pre_sqrt}")
     return jnp.sqrt(pre_sqrt)
 
 

--- a/mesh_transformer/util.py
+++ b/mesh_transformer/util.py
@@ -28,6 +28,7 @@ def gpt3_schedule(warmup_steps,
 
 def global_norm(updates):
     pre_sqrt = sum([jnp.sum(jnp.square(x)) for x in jax.tree_leaves(updates)])
+    pre_sqrt = jax.lax.psum(pre_sqrt, "shard")
     return jnp.sqrt(pre_sqrt)
 
 


### PR DESCRIPTION
- Modifies `CasualTransformer.train` to return gradient norms at the microbatch and single-example level
- Uses these to compute the gradient noise scale estimate `B_simple`, from Appendix A.1 of [An Empirical Model of Large-Batch Training](https://arxiv.org/abs/1812.06162)
- Restores the psum line that was removed [here](https://github.com/kingoflolz/mesh-transformer-jax/commit/02850c46c6b9d957b2a9214c2c6c291269648792#diff-c0219720e7ca7d79c74422022047497e12677c195f846ecf29af21017f6d21dfL21) so V1 grad clipping works properly

(For the psum change, I tried to do something that would turn off the psum in V2, but there's probably a better way to do it.  What I need for this PR to work is just psumming in V1)

----

Computing `B_simple` involves

1. measuring two quantities `G_noise` and `S_noise` that are high-variance across steps
2. taking moving averages to smooth them
3. taking a ratio of the moving averages

I chose to do steps 2-3 inside the script, so we can report the averages and `B_simple` directly to wandb for continual monitoring.  (I don't know a way to compute a ratio of moving averages within wandb itself)

There are some heuristic choices involved, like picking the moving average constant.  One can choose these differently of course -- this code reflects what I currently use, and I've used similar choices in other repos

----

About correctness of the implementation:

I implemented the same thing in mtf gpt-neo earlier, and the results are about the same for similar data / lr.  Both implementations reproduce expected relationships like the roughly inverse one between lr and B_simple.

Longer ago, I calculated B_simple in a (deeply cursed) script for tuning tensorflow gpt-2 on v2-8s, with B_small=20 and B_big=120.  That script gave me larger numbers for B_simple, about 5x.  I'm not sure what explains that difference -- could be a lot of things.
