### PR TITLE
Dockerfile requires apt update before git install

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 # Have tested with a custom Ubuntu-1804 / Python 3.7 / Tensorflow 2.5.0 Base Image
 # Not tested with this image. 
-FROM tensorflow/tensorflow:tensorflow:2.5.0
+FROM tensorflow/tensorflow:2.5.0
 RUN apt update && \
     apt-get install git -y
 


### PR DESCRIPTION
docker-compose will fail without the apt update before installing git.
Additionally pinning the tensorflow container to 2.5.0 as had been tested previously.