### PR TITLE
Lower memory consumption in Colab demo

### DIFF
--- a/colab_demo.ipynb
+++ b/colab_demo.ipynb
@@ -1346,7 +1346,7 @@
     "import optax\n",
     "import transformers\n",
     "\n",
-    "from mesh_transformer.checkpoint import read_ckpt\n",
+    "from mesh_transformer.checkpoint import read_ckpt_lowmem\n",
     "from mesh_transformer.sampling import nucleaus_sample\n",
     "from mesh_transformer.transformer_shard import CausalTransformer"
    ],
@@ -1517,7 +1517,7 @@
     "\n",
     "network = CausalTransformer(params)\n",
     "\n",
-    "network.state = read_ckpt(network.state, \"step_383500/\", devices.shape[1])\n",
+    "network.state = read_ckpt_lowmem(network.state, \"step_383500/\", devices.shape[1])\n",
     "\n",
     "network.state = network.move_xmap(network.state, np.zeros(cores_per_replica))"
    ],

--- a/mesh_transformer/checkpoint.py
+++ b/mesh_transformer/checkpoint.py
@@ -131,30 +131,57 @@ def reshard(x, old_shape):
     return out
 
 
-def read_ckpt(pytree, dir, shards_in):
+def read_ckpt(pytree, dir, shards_in, shards_out=None, load_opt=True):
+    if shards_out is None:
+        shards_out = shards_in
+
     old_flattened, structure = jax.tree_flatten(pytree)
 
-    start = time.time()
-    unsharded = []
-    devices = jax.devices()
-    device_count = len(devices)
-    device_index = 0
-    for file_index in range(pieces):
-        print(f"read_ckpt {file_index}.npz")
-        array_keys = [*np.load(f"{dir}shard_0/{file_index}.npz").keys()]
-        for array_index in range(len(array_keys)):
-            unstacked = []
-            for shard_index in range(shards_in):
-                npz = np.load(f"{dir}shard_{shard_index}/{file_index}.npz")
-                array = npz[array_keys[array_index]]
-                if array.dtype == 'V2':
-                    array.dtype = jnp.bfloat16
-                unstacked.append(array)
-            unsharded.append(jax.device_put(jnp.stack(unstacked), device=devices[device_index % device_count]))
-            device_index += 1
-    print(f"read from disk/gcs in {time.time() - start:.06}s")
+    original_opt_state = pytree["opt_state"]
+
+    def _unshard():
+        start = time.time()
+        unsharded = []
+        devices = jax.devices()
+        device_count = len(devices)
+        device_index = 0
+
+        for file_index in range(pieces):
+            print(f"read_ckpt {file_index}.npz")
+            array_keys = [*np.load(f"{dir}shard_0/{file_index}.npz").keys()]
+            for array_index in range(len(array_keys)):
+                unstacked = []
+                for shard_index in range(shards_in):
+                    npz = np.load(f"{dir}shard_{shard_index}/{file_index}.npz")
+                    array = npz[array_keys[array_index]]
+                    if array.dtype == 'V2':
+                        array.dtype = jnp.bfloat16
+                    unstacked.append(array)
+
+                x = jax.device_put(jnp.stack(unstacked), device=devices[device_index % device_count])
+
+                if shards_out != shards_in:
+                    x = reshard(x, old_flattened[device_index].shape)
+                unsharded.append(x)
+
+                assert x.shape == old_flattened[device_index].shape, f"Incompatible checkpoints {x.shape} vs {old_flattened[device_index].shape}"
+                device_index += 1
+
+        print(f"read from disk/gcs in {time.time() - start:.06}s")
+        return unsharded
+
+    try:
+        unsharded = _unshard()
+    except AssertionError:
+        load_opt = False  # no opt to load in ckpt
+        del pytree['opt_state']
+        old_flattened, structure = jax.tree_flatten(pytree)
+        unsharded = _unshard()
 
     loaded_pytree = jax.tree_unflatten(structure, unsharded)
+
+    if not load_opt:
+        loaded_pytree['opt_state'] = original_opt_state
     return loaded_pytree
 
 

--- a/mesh_transformer/checkpoint.py
+++ b/mesh_transformer/checkpoint.py
@@ -147,7 +147,6 @@ def read_ckpt(pytree, dir, shards_in, shards_out=None, load_opt=True):
         device_index = 0
 
         for file_index in range(pieces):
-            print(f"read_ckpt {file_index}.npz")
             array_keys = [*np.load(f"{dir}shard_0/{file_index}.npz").keys()]
             for array_index in range(len(array_keys)):
                 unstacked = []

--- a/mesh_transformer/checkpoint.py
+++ b/mesh_transformer/checkpoint.py
@@ -141,7 +141,7 @@ def read_ckpt(pytree, dir, shards_in):
     device_index = 0
     for file_index in range(pieces):
         print(f"read_ckpt {file_index}.npz")
-        array_keys = np.load(f"{dir}shard_0/{file_index}.npz").keys()
+        array_keys = [*np.load(f"{dir}shard_0/{file_index}.npz").keys()]
         for array_index in range(len(array_keys)):
             unstacked = []
             for shard_index in range(shards_in):


### PR DESCRIPTION
This pull request includes a new implementation of read_ckpt, named read_ckpt_lowmem, in checkpoint.py that uses less system RAM and more device RAM so that the Colab demo will work correctly on all current TPU Colab instances. The original implementation will crash TPU Colab instances that don't have at least 13-14 GiB of system RAM.