### PR TITLE
add Gopher 230B results

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Models roughly sorted by performance, or by FLOPs if not available.
 | GPT-3-13B*‡     | ✘       | 2.3e22         | 3.56          | 72.5%         | 67.9%        | 70.9%       | 78.5%  | ~800              |
 | GPT-3-175B*‡    | ✘       | 3.1e23         | 3.00          | 76.2%         | 70.2%        | 78.9%       | 81.0%  | ~800              |
 | GPT-3-Davinci‡  | ✘       | -----          | 3.0           | 75%           | 72%          | 78%         | 80%    | -----             |
+| Gopher 230B*	  | ✘	    | 6.31E+23	     | -----    	 | 74.50%        | 70.10%   	| 79.20%      | 81.80% | 1344              |
 | MT-NLG 530B*‡   | ✘       | -----          | -----         | 76.6%         | 73.0%        | 80.2%       | 82.0%  | -----             |
 
 `*` represents evaluation numbers reported by their respective authors, all other numbers are provided by


### PR DESCRIPTION
Paper reports: "For all MassiveText subsets, we filter out non-English documents, process data into a homogeneous text-only format, deduplicate documents, and filter out documents too similar to those in our test sets." Therefore it seems safe to assume no test-set contamination.

https://storage.googleapis.com/deepmind-media/research/language-research/Training%20Gopher.pdf